### PR TITLE
bfix:fixed submission fetching for no submissions

### DIFF
--- a/scripts/codeforces.go
+++ b/scripts/codeforces.go
@@ -110,7 +110,7 @@ func getCodeforcesSubmissionParts(handle string, afterIndex int) submission.Code
 }
 
 func GetCodeforcesSubmissions(handle string, after time.Time) submission.CodeforcesSubmissions {
-	var oldestSubIndex, current int;
+	var oldestSubIndex, current int
 	var oldestSubFound = false
 	var subs submission.CodeforcesSubmissions
 	//Fetch submission until oldest submission not found
@@ -120,7 +120,7 @@ func GetCodeforcesSubmissions(handle string, after time.Time) submission.Codefor
 		if len(newSub.Data) != 0 {
 			for i, sub := range newSub.Data {
 				subs.Data = append(subs.Data, sub)
-				oldestSubIndex = current + i
+				oldestSubIndex = current + i + 1
 				if sub.CreationDate.Equal(after) || sub.CreationDate.Before(after) {
 					oldestSubFound = true
 					break
@@ -129,7 +129,6 @@ func GetCodeforcesSubmissions(handle string, after time.Time) submission.Codefor
 			//50 submissions per page
 			current += 50
 		} else {
-			oldestSubIndex += 1
 			break
 		}
 	}

--- a/scripts/hackerrank.go
+++ b/scripts/hackerrank.go
@@ -30,14 +30,17 @@ type HackerrankContest struct {
 }
 
 func GetRequest(path string) []byte {
-	resp, err := http.Get(path)
+	client := http.Client{Timeout: time.Second * 10}
+	resp, err := client.Get(path)
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
+		return nil
 	}
 	defer resp.Body.Close()
 	byteValue, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err.Error())
+		return nil
 	}
 	return byteValue
 }


### PR DESCRIPTION
Fixed out of bound index due to no submissions in response.
And added timeout and return statement so that ,in case codeforces server is down, it does not break the code.
Fixed #65  